### PR TITLE
Make adjustments to conform to v3

### DIFF
--- a/foundation.go
+++ b/foundation.go
@@ -34,10 +34,6 @@ var (
 	r = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	sequenceID uint64 = 0
-
-	v3ErrorMarshalFunc = func(err error) interface{} {
-		return v3Error{"narancs"}
-	}
 )
 
 type messageIDHook struct{}
@@ -101,7 +97,9 @@ func InitV3Logging(appgroup, app, version, branch, revision, buildDate string) {
 		Logger()
 
 	// Have the error message under and object in "error" instead of in a raw string.
-	zerolog.ErrorMarshalFunc = v3ErrorMarshalFunc
+	zerolog.ErrorMarshalFunc = func(err error) interface{} {
+		return v3Error{err.Error()}
+	}
 
 	// use zerolog for any logs sent via standard log library
 	stdlog.SetFlags(0)

--- a/foundation.go
+++ b/foundation.go
@@ -105,7 +105,28 @@ func InitV3Logging(appgroup, app, version, branch, revision, buildDate string) {
 	stdlog.SetFlags(0)
 	stdlog.SetOutput(log.Logger)
 
-	LogStartupMessage(appgroup, app, version, branch, revision, buildDate)
+	LogStartupMessageV3(appgroup, app, version, branch, revision, buildDate)
+}
+
+// LogStartupMessageV3 logs a v3 startup message for any Estafette application
+func LogStartupMessageV3(appgroup, app, version, branch, revision, buildDate string) {
+	startupProps := struct {
+		Branch    string `json:"branch"`
+		Revision  string `json:"revision"`
+		BuildDate string `json:"buildDate"`
+		GoVersion string `json:"goVersion"`
+		Os        string `json:"os"`
+	}{
+		branch,
+		revision,
+		buildDate,
+		goVersion,
+		runtime.GOOS,
+	}
+
+	log.Info().
+		Interface("payload", startupProps).
+		Msgf("Starting %v version %v...", app, version)
 }
 
 // InitStackdriverLogging initializes logging to log everything as json optimized for Stackdriver logging
@@ -174,22 +195,12 @@ func InitConsoleLogging(appgroup, app, version, branch, revision, buildDate stri
 
 // LogStartupMessage logs a default startup message for any Estafette application
 func LogStartupMessage(appgroup, app, version, branch, revision, buildDate string) {
-	startupProps := struct {
-		Branch    string `json:"branch"`
-		Revision  string `json:"revision"`
-		BuildDate string `json:"buildDate"`
-		GoVersion string `json:"goVersion"`
-		Os        string `json:"os"`
-	}{
-		branch,
-		revision,
-		buildDate,
-		goVersion,
-		runtime.GOOS,
-	}
-
 	log.Info().
-		Interface("payload", startupProps).
+		Str("branch", branch).
+		Str("revision", revision).
+		Str("buildDate", buildDate).
+		Str("goVersion", goVersion).
+		Str("os", runtime.GOOS).
 		Msgf("Starting %v version %v...", app, version)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/fsnotify/fsnotify v1.4.7
+	github.com/google/uuid v1.1.1
 	github.com/prometheus/client_golang v0.9.2
 	github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f // indirect
 	github.com/prometheus/common v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=


### PR DESCRIPTION
We have some log messages ending up in the dead letter queue due to not being able to be inserted into the v3 index.  
The PR does the following changes to address this:

 - With the `v3` format `error` is expected to be an object with a `message` (and possibly others) field. This is adjusted with the `ErrorMarshalFunc`.
 - And to conform to `v3`, the `messageuniqueid` and the `sequenceid` fields were missing, these were added. (Although this doesn't cause dead messages.)

I also wrapped the startup properties in an object under `payload`, because that's where custom fields should go in `v3`. Unfortunately I don't see any way to enforce this for all users. So even if someone uses this logger, but then does
```
log.Str("foo", "bar")
```
Then the `foo` key will end up on the root level, and I couldn't find a way to prevent that.